### PR TITLE
Exception handling for empty LDAP result added

### DIFF
--- a/wpDirAuth.php
+++ b/wpDirAuth.php
@@ -488,11 +488,24 @@ else {
                  */
                 if ( $isPreBound = wpDirAuth_bindTest($connection, $preBindUser, $preBindPassword,$baseDn) === true ) {
                     if ( ($results = @ldap_search($connection, $baseDn, $filterQuery, $returnKeys)) !== false ) {
-                        if ( ($userDn = @ldap_get_dn($connection, ldap_first_entry($connection, $results))) !== false ) {
-                            if ( ($isBound = wpDirAuth_bindTest($connection, $userDn, $password,$baseDn)) === true ) {
-                                $isLoggedIn = true; // valid server, valid login, move on
-                                break; // valid server, valid login, move on
+                        // Check if the search returned any entries
+                        if (ldap_count_entries($connection, $results) > 0) {
+                            $firstEntry = ldap_first_entry($connection, $results);
+                            if ($firstEntry !== false) {
+                                if ( ($userDn = @ldap_get_dn($connection, $firstEntry)) !== false ) {
+                                    if ( ($isBound = wpDirAuth_bindTest($connection, $userDn, $password, $baseDn)) === true ) {
+                                        $isLoggedIn = true; // valid server, valid login, move on
+                                        break; // valid server, valid login, move on
+                                    }
+                                }
                             }
+                        } else {
+                            // Log that no results were found
+                            $errorMessage = "LDAP search returned no entries for query: $filterQuery";
+                            error_log($errorMessage);
+
+                            // Return a WP_Error with the same message
+                            return new WP_Error('ldap_search_failed', __($errorMessage));
                         }
                     }
                 }


### PR DESCRIPTION
## Error:
```
# grep EXCEPTION /var/log/php-fpm/www-error.log
[24-Sep-2024 08:22:39 UTC] EXCEPTION: ldap_get_dn(): Argument #2 ($entry) must be of type resource, bool given in /var/www/html/veranstaltungsregistrierung/wp-content/plugins/wpdirauth/wpDirAuth.php on line 491
```
## Reproduction:
Submit wp-login.php with wrong username

## Versions:
* Worpress  6.4.2
* wpDirAuth: 1.10.7
* PHP 8.0.30 

## See also:
https://wordpress.org/support/topic/error-on-php8-1-when-user-does-not-exist/